### PR TITLE
Fixed bug related to SolidQueue background jobs:

### DIFF
--- a/app/views/shared/_dashboard_collection_tracks.html.erb
+++ b/app/views/shared/_dashboard_collection_tracks.html.erb
@@ -16,7 +16,7 @@
     </div>
     <div class="d-flex flex-column justify-content-center">
       <div class="d-flex justify-content-end">
-        <% if SolidQueue::Job.all.any? { |job| job.arguments["arguments"][0]["collection"].present? && job.arguments["arguments"][0]["order"].to_i == order.id } && (!collection.download_links.present? || collection.download_links.last.expired?) %>
+        <% if SolidQueue::Job.where(class_name: "ZipCollectionJob").any? { |job| job.arguments["arguments"][0]["collection"].present? && job.arguments["arguments"][0]["order"].to_i == order.id } && (!collection.download_links.present? || collection.download_links.last.expired?) %>
           <div class="loader"></div>
         <% elsif collection.download_links.present? && !collection.download_links.last.expired? %>
           <a href="<%= collection.download_links.last.url %>"

--- a/app/views/shared/_dashboard_collection_tracks_mobile.html.erb
+++ b/app/views/shared/_dashboard_collection_tracks_mobile.html.erb
@@ -18,7 +18,7 @@
     </div>
     <div class="d-flex flex-column justify-content-center">
       <div class="d-flex justify-content-center">
-        <% if SolidQueue::Job.all.any? { |job| job.arguments["arguments"][0]["collection"].present? && job.arguments["arguments"][0]["order"].to_i == order.id } && (!collection.download_links.present? || collection.download_links.last.expired?) %>
+        <% if SolidQueue::Job.where(class_name: "ZipCollectionJob").any? { |job| job.arguments["arguments"][0]["collection"].present? && job.arguments["arguments"][0]["order"].to_i == order.id } && (!collection.download_links.present? || collection.download_links.last.expired?) %>
           <div class="loader"></div>
         <% elsif collection.download_links.present? && !collection.download_links.last.expired? %>
           <a href="<%= collection.download_links.last.url %>"

--- a/app/views/shared/_dashboard_single_tracks.html.erb
+++ b/app/views/shared/_dashboard_single_tracks.html.erb
@@ -19,7 +19,7 @@
     </div>
     <div class="d-flex flex-column justify-content-center">
       <div class="d-flex justify-content-end">
-        <% if SolidQueue::Job.all.any? { |job| job.arguments["arguments"][0]["type"] == "single_tracks" && job.arguments["arguments"][0]["order"].to_i == order.id } && (!order.download_links.where(collection_download: false).present? || order.download_links.where(collection_download: false).last.expired?) %>
+        <% if SolidQueue::Job.where(class_name: "ZipCollectionJob").any? { |job| job.arguments["arguments"][0]["type"] == "single_tracks" && job.arguments["arguments"][0]["order"].to_i == order.id } && (!order.download_links.where(collection_download: false).present? || order.download_links.where(collection_download: false).last.expired?) %>
           <div class="loader"></div>
         <% elsif order.download_links.where(collection_download: false).present? && !order.download_links.where(collection_download: false).last.expired? %>
           <a href="<%= order.download_links.where(collection_download: false).last.url %>"

--- a/app/views/shared/_dashboard_single_tracks_mobile.html.erb
+++ b/app/views/shared/_dashboard_single_tracks_mobile.html.erb
@@ -21,7 +21,7 @@
     </div>
     <div class="d-flex flex-column justify-content-center">
       <div class="d-flex justify-content-center">
-        <% if SolidQueue::Job.all.any? { |job| job.arguments["arguments"][0]["type"] == "single_tracks" && job.arguments["arguments"][0]["order"].to_i == order.id } && (!order.download_links.where(collection_download: false).present? || order.download_links.where(collection_download: false).last.expired?) %>
+        <% if SolidQueue::Job.where(class_name: "ZipCollectionJob").any? { |job| job.arguments["arguments"][0]["type"] == "single_tracks" && job.arguments["arguments"][0]["order"].to_i == order.id } && (!order.download_links.where(collection_download: false).present? || order.download_links.where(collection_download: false).last.expired?) %>
           <div class="loader"></div>
         <% elsif order.download_links.where(collection_download: false).present? && !order.download_links.where(collection_download: false).last.expired? %>
           <a href="<%= order.download_links.where(collection_download: false).last.url %>"


### PR DESCRIPTION
Since added the Mailer background jobs, the Dashboard display was not filtering out Mailerjobs when looking for Zipping jobs which was throwing an error.